### PR TITLE
make jcenter build work on docker file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,16 +71,6 @@
             <version>7.1.4</version>
         </dependency>
         <dependency>
-            <groupId>no.uio.ifi</groupId>
-            <artifactId>crypt4gh</artifactId>
-            <version>2.4.2</version>
-        </dependency>
-        <dependency>
-            <groupId>no.uio.ifi</groupId>
-            <artifactId>clearinghouse</artifactId>
-            <version>1.1.0</version>
-        </dependency>
-        <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>6.4</version>
@@ -90,15 +80,37 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>no.uio.ifi</groupId>
+          <artifactId>crypt4gh</artifactId>
+          <version>2.4.2</version>
+            <exclusions>
+             <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+             </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>no.uio.ifi</groupId>
+            <artifactId>clearinghouse</artifactId>
+            <version>1.1.0</version>
+            <exclusions>
+             <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+             </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>central</id>
-            <name>bintray</name>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
-    </repositories>
+     <repositories>
+         <repository>
+             <id>jcenter</id>
+             <name>jcenter</name>
+             <url>https://jcenter.bintray.com</url>
+         </repository>
+     </repositories>
 
     <build>
         <plugins>


### PR DESCRIPTION
for some reason the dependencies were not properly retrieved from jcenter with the id `central`

this aims to fix broken docker builds: https://hub.docker.com/repository/docker/neicnordic/sda-doa/builds