### PR TITLE
Retrieve decrypted filesize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>no.uio.ifi</groupId>
     <artifactId>localega-doa</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>localega-doa</name>
     <description>LocalEGA Data Out API</description>
 

--- a/src/main/java/no/uio/ifi/localega/doa/dto/File.java
+++ b/src/main/java/no/uio/ifi/localega/doa/dto/File.java
@@ -19,6 +19,9 @@ public class File {
     private Long fileSize;
     private String unencryptedChecksum;
     private String unencryptedChecksumType;
+    private Long decryptedFileSize;
+    private String decryptedFileChecksum;
+    private String decryptedFileChecksumType;
     private String fileStatus;
 
 }

--- a/src/main/java/no/uio/ifi/localega/doa/model/LEGAFile.java
+++ b/src/main/java/no/uio/ifi/localega/doa/model/LEGAFile.java
@@ -43,6 +43,7 @@ public class LEGAFile {
     @Column(name = "display_file_name", insertable = false, updatable = false, length = 128)
     private String displayFileName;
 
+    // This is the size of the file that is in the archive, the encrypted part of the file
     @Column(name = "file_size", insertable = false, updatable = false)
     private Long fileSize;
 
@@ -61,6 +62,15 @@ public class LEGAFile {
     @Size(max = 12)
     @Column(name = "unencrypted_checksum_type", insertable = false, updatable = false, length = 12)
     private String unencryptedChecksumType;
+
+    @Column(name = "decrypted_file_size", insertable = false, updatable = false)
+    private Long decryptedFileSize;
+
+    @Column(name = "decrypted_file_checksum", insertable = false, updatable = false)
+    private String decryptedFileChecksum;
+
+    @Column(name = "decrypted_file_checksum_type", insertable = false, updatable = false)
+    private String decryptedFileChecksumType;
 
     @Size(max = 13)
     @Column(name = "file_status", insertable = false, updatable = false, length = 13)

--- a/src/main/java/no/uio/ifi/localega/doa/services/MetadataService.java
+++ b/src/main/java/no/uio/ifi/localega/doa/services/MetadataService.java
@@ -58,6 +58,9 @@ public class MetadataService {
                     file.setDisplayFileName(f.getDisplayFileName());
                     file.setFileName(f.getFileName());
                     file.setFileSize(f.getFileSize());
+                    file.setDecryptedFileSize(f.getDecryptedFileSize());
+                    file.setDecryptedFileChecksum(f.getDecryptedFileChecksum());
+                    file.setDecryptedFileChecksumType(f.getDecryptedFileChecksumType());
                     file.setUnencryptedChecksum(f.getUnencryptedChecksum());
                     file.setUnencryptedChecksumType(f.getUnencryptedChecksumType());
                     file.setFileStatus(f.getFileStatus());


### PR DESCRIPTION
This is related to db changes done in: https://github.com/neicnordic/sda-db/pull/15
Also it is dependent on https://github.com/neicnordic/sda-pipeline/issues/142 

The purpose is to display the decrypted file size when a request is made for the plain decrypted file and even to compare if the decrypted file size matches in with what is recorded in the SDA DB

dependent on: https://github.com/neicnordic/sda-pipeline/pull/153